### PR TITLE
Feat: support nextjs config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ Generate version infomation file in webpack output folder
 
 ## usage
 
+```shell
+npm i -D version-file-webpack-plugin
+
+# or
+
+yarn add -D version-file-webpack-plugin
 ```
+
+```shell
 # install dependencies
 yarn
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ yarn test
 | options                | type           | default                            | description                                                                                                                |
 | ---------------------- | -------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | output                 | string         | \_\_version.json                   | file path                                                                                                                  |
+| absolute               | boolean        | false                              | Absolute path of output                                                                                                    |
 | data                   | object         | `{}`                               | output data                                                                                                                |
 | jsonStringify.replacer | array          | null                               | JSON.stringify [replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) |
 | jsonStringify.space    | string\|number | 2                                  | JSON.stringify [space](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)    |
@@ -48,11 +49,37 @@ module.exports = {
   // ...
   plugins: [
     new VersionPlugin({
-      output: '__info/version.txt',
+      output: '__info/version.txt', // @default `__version.json`
       data: process.env,
     });
   ],
 };
+```
+
+### nextjs
+
+[custom webpack config](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config)
+
+```js
+// next.config.js
+
+module.exports = {
+  webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
+    config.plugins.push(
+      new versionFile({
+        data: process.env,
+      })
+    );
+
+    return config;
+  },
+};
+```
+
+`.gitignore`
+
+```
+/public/[output]
 ```
 
 ## license

--- a/package.json
+++ b/package.json
@@ -34,12 +34,14 @@
   "devDependencies": {
     "@ava/babel": "^1.0.1",
     "@ava/typescript": "^1.1.1",
+    "@types/mock-fs": "^4.13.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
     "ava": "^3.15.0",
     "eslint": "^7.19.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "mock-fs": "^4.14.0",
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,14 @@
 import test from "ava";
+import fs from "fs";
+import mock from "mock-fs";
 
 import VersionPlugin from "../src";
+
+test.beforeEach(() => {
+  mock({
+    "/dir/repo": {},
+  });
+});
 
 test("base exist", (t) => {
   const plugin = new VersionPlugin();
@@ -25,4 +33,36 @@ test("options", (t) => {
 
   t.is(plugin.options.output, "version/index.txt");
   t.deepEqual(plugin.options.data, { 1: "demo01", b: "demo02" });
+});
+
+test("apply()", (t) => {
+  const plugin01 = new VersionPlugin({
+    data: { 1: "demo01", b: "demo02" },
+  });
+
+  t.is(plugin01.options.output, "__version.json");
+  t.deepEqual(plugin01.options.data, { 1: "demo01", b: "demo02" });
+
+  t.is(fs.existsSync("/dir/repo01/__version.json"), false);
+
+  plugin01.apply({ options: { output: { path: "/dir/repo01" } } } as any);
+
+  t.is(fs.existsSync("/dir/repo01/__version.json"), true);
+
+  const plugin02 = new VersionPlugin({
+    output: "/version/index.txt",
+    absolute: true,
+    data: { 1: "demo01", b: "demo02" },
+  });
+
+  t.is(plugin02.options.output, "/version/index.txt");
+  t.deepEqual(plugin02.options.data, { 1: "demo01", b: "demo02" });
+
+  t.is(fs.existsSync("/dir/repo02/version/index.txt"), false);
+  t.is(fs.existsSync("/version/index.txt"), false);
+
+  plugin02.apply({ options: { output: { path: "/dir/repo02" } } } as any);
+
+  t.is(fs.existsSync("/dir/repo02/version/index.txt"), false);
+  t.is(fs.existsSync("/version/index.txt"), true);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,6 +388,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/mock-fs@^4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@types/mock-fs/-/mock-fs-4.13.0.tgz#b8b01cd2db588668b2532ecd21b1babd3fffb2c0"
+  integrity sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.0.tgz#557dd0da4a6dca1407481df3bbacae0cd6f68042"
@@ -2374,6 +2381,11 @@ minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+mock-fs@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
+  integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
1. feat: support nextjs config
```js
// next.config.js
module.exports = {
  webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
    config.plugins.push(
      new versionFile({
        data: process.env,
      })
    );
    return config;
  },
};
```

`.gitignore`

```diff
+/public/[output]
```

2. feat: support absolute path of output. 